### PR TITLE
Compilation fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,17 +2,20 @@
 
 
 [[projects]]
+  digest = "1:d5039f72505274cddd25fef3b4790e7d985eaf063a0c7df1363ed6292ddc30fb"
   name = "github.com/aws/aws-lambda-go"
   packages = [
     "events",
     "lambda",
     "lambda/messages",
-    "lambdacontext"
+    "lambdacontext",
   ]
+  pruneopts = ""
   revision = "6e2e37798efbb1dfd8e9c6681702e683a6046517"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:ea5f610419c5dfdbf17c507bc449b81dafda953e94a003c9669bfa643767fe4f"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -42,25 +45,38 @@
     "service/dynamodb",
     "service/dynamodb/dynamodbattribute",
     "service/dynamodb/expression",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = ""
   revision = "788eb15477cf129a45d8e1d0af5f533348f4125d"
   version = "v1.12.78"
 
 [[projects]]
+  digest = "1:a00483fe4106b86fb1187a92b5cf6915c85f294ed4c129ccbe7cb1f1a06abd46"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = ""
   revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
   version = "v1.32.0"
 
 [[projects]]
+  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "0b12d6b5"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3ac487e39af6b47736eb934f4d62970d97196ed4f8aff1c6359a5ddda2e1ec91"
+  input-imports = [
+    "github.com/aws/aws-lambda-go/events",
+    "github.com/aws/aws-lambda-go/lambda",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/dynamodb",
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute",
+    "github.com/aws/aws-sdk-go/service/dynamodb/expression",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ build: | vendor
 	env GOOS=linux go build -ldflags="-s -w" -o bin/put functions/put.go functions/moviedao.go
 	env GOOS=linux go build -ldflags="-s -w" -o bin/list-by-year functions/list-by-year.go functions/moviedao.go
 
-vendor:
+vendor: Gopkg.toml
 	dep ensure

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-build: | vendor
-	env GOOS=linux go build -ldflags="-s -w" -o bin/get functions/get.go functions/moviedao.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/post functions/post.go functions/moviedao.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/delete functions/delete.go functions/moviedao.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/put functions/put.go functions/moviedao.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/list-by-year functions/list-by-year.go functions/moviedao.go
+go_apps = bin/get bin/post bin/delete bin/put bin/list-by-year
+
+bin/% : functions/%.go
+	env GOOS=linux go build -ldflags="-s -w" -o $@ $< functions/comicinfo_dao.go functions/shared.go
+
+build: $(go_apps) | vendor
 
 vendor: Gopkg.toml
 	dep ensure

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
-build:
+build: | vendor
+	env GOOS=linux go build -ldflags="-s -w" -o bin/get functions/get.go functions/moviedao.go
+	env GOOS=linux go build -ldflags="-s -w" -o bin/post functions/post.go functions/moviedao.go
+	env GOOS=linux go build -ldflags="-s -w" -o bin/delete functions/delete.go functions/moviedao.go
+	env GOOS=linux go build -ldflags="-s -w" -o bin/put functions/put.go functions/moviedao.go
+	env GOOS=linux go build -ldflags="-s -w" -o bin/list-by-year functions/list-by-year.go functions/moviedao.go
+
+vendor:
 	dep ensure
-	env GOOS=linux go build -ldflags="-s -w" -o bin/get functions/get.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/post functions/post.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/delete functions/delete.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/put functions/put.go
-	env GOOS=linux go build -ldflags="-s -w" -o bin/list-by-year functions/list-by-year.go

--- a/functions/delete.go
+++ b/functions/delete.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"go-sls-crudl/moviedao"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -23,7 +22,7 @@ func parseSlug(orig string) (retval string) {
 func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Make the call to the DAO with params found in the path
 	fmt.Println("Path vars: ", request.PathParameters["year"], " ", parseSlug(request.PathParameters["title"]))
-	err := moviedao.Delete(request.PathParameters["year"], parseSlug(request.PathParameters["title"]))
+	err := Delete(request.PathParameters["year"], parseSlug(request.PathParameters["title"]))
 	if err != nil {
 		panic(fmt.Sprintf("Failed to find Item, %v", err))
 	}

--- a/functions/get.go
+++ b/functions/get.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"go-sls-crudl/moviedao"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -24,7 +23,7 @@ func parseSlug(orig string) (retval string) {
 func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Make the call to the DAO with params found in the path
 	fmt.Println("Path vars: ", request.PathParameters["year"], " ", parseSlug(request.PathParameters["title"]))
-	item, err := moviedao.GetByYearTitle(request.PathParameters["year"], parseSlug(request.PathParameters["title"]))
+	item, err := GetByYearTitle(request.PathParameters["year"], parseSlug(request.PathParameters["title"]))
 	if err != nil {
 		panic(fmt.Sprintf("Failed to find Item, %v", err))
 	}

--- a/functions/list-by-year.go
+++ b/functions/list-by-year.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"go-sls-crudl/moviedao"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -16,7 +15,7 @@ type Response struct {
 func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Make the call to the DAO with params found in the path
 	fmt.Println("Path vars: ", request.PathParameters["year"])
-	items, err := moviedao.ListByYear(request.PathParameters["year"])
+	items, err := ListByYear(request.PathParameters["year"])
 	if err != nil {
 		panic(fmt.Sprintf("Failed to find Item, %v", err))
 	}

--- a/functions/moviedao.go
+++ b/functions/moviedao.go
@@ -1,4 +1,4 @@
-package moviedao
+package main
 
 import (
 	"encoding/json"

--- a/functions/post.go
+++ b/functions/post.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"go-sls-crudl/moviedao"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -11,7 +10,7 @@ import (
 func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Log body and pass to the DAO
 	fmt.Println("Received body: ", request.Body)
-	item, err := moviedao.Post(request.Body)
+	item, err := Post(request.Body)
 	if err != nil {
 		fmt.Println("Got error calling post")
 		fmt.Println(err.Error())

--- a/functions/put.go
+++ b/functions/put.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"go-sls-crudl/moviedao"
 
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -11,7 +10,7 @@ import (
 func Handler(request events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
 	// Log body and pass to the DAO
 	fmt.Println("Received body: ", request.Body)
-	item, err := moviedao.Put(request.Body)
+	item, err := Put(request.Body)
 	if err != nil {
 		fmt.Println("Got error calling put")
 		fmt.Println(err.Error())


### PR DESCRIPTION
Hi -- so my changes are kind of awful, but (IMHO!) the way the AWS team have set up using "go" is kind of awful (I blame you not at all).

My changes: Alas, it appears that "moviedao.go" has to go in the "functions" directory (and the "main" package) so that the compilation lines become:

    env GOOS=linux go build -ldflags="-s -w" -o bin/get functions/get.go functions/moviedao.go

I did improve the `Makefile` so that it only runs the `dep ensure` when the `vendor` directory does not exist... of course, that means that if you update the `Gopkg.toml` file, you'll have to either do the `dep ensure` yourself or remember to remove the `vendor` directory.

But it does make the `make` run faster, at least on my machine.