### PR TITLE
Fixed code dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 go_apps = bin/get bin/post bin/delete bin/put bin/list-by-year
 
-bin/% : functions/%.go functions/moviedao.go functions/shared.go
-	env GOOS=linux go build -ldflags="-s -w" -o $@ $< functions/moviedao.go functions/shared.go
+bin/% : functions/%.go functions/moviedao.go
+	env GOOS=linux go build -ldflags="-s -w" -o $@ $< functions/moviedao.go
 
 build: $(go_apps) | vendor
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 go_apps = bin/get bin/post bin/delete bin/put bin/list-by-year
 
-bin/% : functions/%.go
+bin/% : functions/%.go functions/comicinfo_dao.go functions/shared.go
 	env GOOS=linux go build -ldflags="-s -w" -o $@ $< functions/comicinfo_dao.go functions/shared.go
 
 build: $(go_apps) | vendor

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 go_apps = bin/get bin/post bin/delete bin/put bin/list-by-year
 
-bin/% : functions/%.go functions/comicinfo_dao.go functions/shared.go
-	env GOOS=linux go build -ldflags="-s -w" -o $@ $< functions/comicinfo_dao.go functions/shared.go
+bin/% : functions/%.go functions/moviedao.go functions/shared.go
+	env GOOS=linux go build -ldflags="-s -w" -o $@ $< functions/moviedao.go functions/shared.go
 
 build: $(go_apps) | vendor
 


### PR DESCRIPTION
Fixed code dependencies so that all 'bin' outputs depend on the utility function files.

Before this fix, if you changed the 'moviedao.go' file, nothing would be rebuilt.